### PR TITLE
Vitest を導入し純粋関数のテストを追加

### DIFF
--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -1,0 +1,134 @@
+import { MAX_ITEMS, STORAGE_KEY } from '@limited/config'
+import type { Countdown } from '@limited/ui'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadCountdowns, storeContext } from './store'
+
+const FIXED_NOW = new Date('2026-04-26T00:00:00.000Z').getTime()
+
+function makeCountdown(overrides: Partial<Countdown> = {}): Countdown {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    title: overrides.title ?? 'sample',
+    deadline: overrides.deadline ?? FIXED_NOW + 86_400_000,
+    startedAt: overrides.startedAt ?? FIXED_NOW,
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_NOW)
+  localStorage.clear()
+  loadCountdowns()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('loadCountdowns', () => {
+  it('localStorage 空のときは空配列', () => {
+    loadCountdowns()
+    expect(storeContext.countdowns()).toEqual([])
+    expect(storeContext.loaded()).toBe(true)
+  })
+
+  it('保存済みデータを読み込む', () => {
+    const items = [makeCountdown({ title: 'a' }), makeCountdown({ title: 'b' })]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
+    loadCountdowns()
+    expect(storeContext.countdowns()).toHaveLength(2)
+    expect(storeContext.countdowns()[0].title).toBe('a')
+  })
+
+  it('壊れた JSON は空配列にフォールバック', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-json')
+    loadCountdowns()
+    expect(storeContext.countdowns()).toEqual([])
+  })
+
+  it('startedAt 欠損は Date.now() で補完', () => {
+    const items = [{ id: 'x', title: 't', deadline: FIXED_NOW + 1000, startedAt: 0 }]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
+    loadCountdowns()
+    expect(storeContext.countdowns()[0].startedAt).toBe(FIXED_NOW)
+  })
+})
+
+describe('addCountdown', () => {
+  it('新規追加して true を返す', async () => {
+    const ok = await storeContext.addCountdown('todo', FIXED_NOW + 1000, FIXED_NOW)
+    expect(ok).toBe(true)
+    expect(storeContext.countdowns()).toHaveLength(1)
+    expect(storeContext.countdowns()[0].title).toBe('todo')
+  })
+
+  it('localStorage に永続化する', async () => {
+    await storeContext.addCountdown('todo', FIXED_NOW + 1000, FIXED_NOW)
+    const raw = localStorage.getItem(STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    const stored = JSON.parse(raw ?? '[]')
+    expect(stored).toHaveLength(1)
+    expect(stored[0].title).toBe('todo')
+  })
+
+  it('MAX_ITEMS に到達したら false を返し、追加しない', async () => {
+    for (let i = 0; i < MAX_ITEMS; i++) {
+      await storeContext.addCountdown(`t${i}`, FIXED_NOW + 1000, FIXED_NOW)
+    }
+    expect(storeContext.countdowns()).toHaveLength(MAX_ITEMS)
+    const ok = await storeContext.addCountdown('overflow', FIXED_NOW + 1000, FIXED_NOW)
+    expect(ok).toBe(false)
+    expect(storeContext.countdowns()).toHaveLength(MAX_ITEMS)
+  })
+})
+
+describe('updateCountdown', () => {
+  it('該当 id のフィールドを更新する', async () => {
+    await storeContext.addCountdown('a', FIXED_NOW + 1000, FIXED_NOW)
+    const id = storeContext.countdowns()[0].id
+    await storeContext.updateCountdown(id, { title: 'renamed' })
+    expect(storeContext.countdowns()[0].title).toBe('renamed')
+  })
+
+  it('部分更新で他フィールドは保持', async () => {
+    await storeContext.addCountdown('a', FIXED_NOW + 1000, FIXED_NOW)
+    const id = storeContext.countdowns()[0].id
+    await storeContext.updateCountdown(id, { deadline: FIXED_NOW + 5000 })
+    expect(storeContext.countdowns()[0].title).toBe('a')
+    expect(storeContext.countdowns()[0].deadline).toBe(FIXED_NOW + 5000)
+  })
+
+  it('存在しない id は何もしない', async () => {
+    await storeContext.addCountdown('a', FIXED_NOW + 1000, FIXED_NOW)
+    const before = storeContext.countdowns()[0]
+    await storeContext.updateCountdown('non-existent', { title: 'x' })
+    expect(storeContext.countdowns()[0]).toEqual(before)
+  })
+
+  it('localStorage にも反映', async () => {
+    await storeContext.addCountdown('a', FIXED_NOW + 1000, FIXED_NOW)
+    const id = storeContext.countdowns()[0].id
+    await storeContext.updateCountdown(id, { title: 'renamed' })
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+    expect(stored[0].title).toBe('renamed')
+  })
+})
+
+describe('removeCountdown', () => {
+  it('該当 id を削除', async () => {
+    await storeContext.addCountdown('a', FIXED_NOW + 1000, FIXED_NOW)
+    await storeContext.addCountdown('b', FIXED_NOW + 1000, FIXED_NOW)
+    const id = storeContext.countdowns()[0].id
+    await storeContext.removeCountdown(id)
+    expect(storeContext.countdowns()).toHaveLength(1)
+    expect(storeContext.countdowns()[0].title).toBe('b')
+  })
+
+  it('localStorage にも反映', async () => {
+    await storeContext.addCountdown('a', FIXED_NOW + 1000, FIXED_NOW)
+    const id = storeContext.countdowns()[0].id
+    await storeContext.removeCountdown(id)
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+    expect(stored).toEqual([])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "deploy:ext": "pnpm build:ext && rm -f limited-extension.zip && cd apps/extension/dist && zip -r ../../../limited-extension.zip .",
     "format": "biome format --write .",
     "lint": "biome lint .",
-    "check": "biome check --write ."
+    "check": "biome check --write .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
+    "happy-dom": "20.9.0",
+    "vitest": "4.1.5",
     "wrangler": "^4.81.1"
   }
 }

--- a/packages/ui/src/countdown-card/utils.test.ts
+++ b/packages/ui/src/countdown-card/utils.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { consumed, elapsedDays, formatDate, formatDateISO } from './utils'
+
+describe('elapsedDays', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-26T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('開始直後は 0d elapsed', () => {
+    expect(elapsedDays(Date.now())).toBe('0d elapsed')
+  })
+
+  it('5 日経過を返す', () => {
+    const fiveDaysAgo = Date.now() - 5 * 24 * 60 * 60 * 1000
+    expect(elapsedDays(fiveDaysAgo)).toBe('5d elapsed')
+  })
+
+  it('未来の startedAt は負数 (Math.floor で繰り下げ)', () => {
+    const future = Date.now() + 24 * 60 * 60 * 1000
+    expect(elapsedDays(future)).toBe('-1d elapsed')
+  })
+})
+
+describe('consumed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-26T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('開始直後は 0%', () => {
+    const start = Date.now()
+    const end = start + 10 * 24 * 60 * 60 * 1000
+    expect(consumed(start, end)).toBe(0)
+  })
+
+  it('中間地点で 50%', () => {
+    const start = Date.now() - 5 * 24 * 60 * 60 * 1000
+    const end = Date.now() + 5 * 24 * 60 * 60 * 1000
+    expect(consumed(start, end)).toBe(50)
+  })
+
+  it('期限到達で 100%', () => {
+    const start = Date.now() - 10 * 24 * 60 * 60 * 1000
+    const end = Date.now()
+    expect(consumed(start, end)).toBe(100)
+  })
+
+  it('期限超過は 100% にクランプ', () => {
+    const start = Date.now() - 20 * 24 * 60 * 60 * 1000
+    const end = Date.now() - 10 * 24 * 60 * 60 * 1000
+    expect(consumed(start, end)).toBe(100)
+  })
+
+  it('開始前は 0% にクランプ', () => {
+    const start = Date.now() + 5 * 24 * 60 * 60 * 1000
+    const end = Date.now() + 10 * 24 * 60 * 60 * 1000
+    expect(consumed(start, end)).toBe(0)
+  })
+
+  it('total <= 0 のときは 100%', () => {
+    const start = Date.now()
+    expect(consumed(start, start)).toBe(100)
+    expect(consumed(start, start - 1000)).toBe(100)
+  })
+})
+
+describe('formatDate', () => {
+  it('YYYY-MM-DD HH:MM 形式', () => {
+    const ts = new Date(2026, 3, 26, 14, 30).getTime()
+    expect(formatDate(ts)).toBe('2026-04-26 14:30')
+  })
+
+  it('1 桁の月日時分はゼロパディング', () => {
+    const ts = new Date(2026, 0, 5, 7, 9).getTime()
+    expect(formatDate(ts)).toBe('2026-01-05 07:09')
+  })
+})
+
+describe('formatDateISO', () => {
+  it('YYYY-MM-DDTHH:MM 形式 (datetime-local 用)', () => {
+    const ts = new Date(2026, 3, 26, 14, 30).getTime()
+    expect(formatDateISO(ts)).toBe('2026-04-26T14:30')
+  })
+
+  it('1 桁の月日時分はゼロパディング', () => {
+    const ts = new Date(2026, 0, 5, 7, 9).getTime()
+    expect(formatDateISO(ts)).toBe('2026-01-05T07:09')
+  })
+})

--- a/packages/ui/src/countdown.test.ts
+++ b/packages/ui/src/countdown.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { calcTimeRemaining, padNum, padYear } from './countdown'
+
+describe('padNum', () => {
+  it('左ゼロパディング (デフォルト 2 桁)', () => {
+    expect(padNum(0)).toBe('00')
+    expect(padNum(5)).toBe('05')
+    expect(padNum(42)).toBe('42')
+  })
+
+  it('指定桁数より大きい数値はそのまま', () => {
+    expect(padNum(123)).toBe('123')
+    expect(padNum(1000)).toBe('1000')
+  })
+
+  it('len 引数でパディング桁数を指定できる', () => {
+    expect(padNum(7, 3)).toBe('007')
+    expect(padNum(7, 5)).toBe('00007')
+  })
+})
+
+describe('padYear', () => {
+  it('4 桁にゼロパディング', () => {
+    expect(padYear(0)).toBe('0000')
+    expect(padYear(99)).toBe('0099')
+    expect(padYear(2024)).toBe('2024')
+  })
+
+  it('5 桁以上はそのまま', () => {
+    expect(padYear(10000)).toBe('10000')
+  })
+})
+
+describe('calcTimeRemaining', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-26T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('期限切れ (deadline <= now) のとき expired: true', () => {
+    const past = new Date('2026-04-25T00:00:00.000Z').getTime()
+    const result = calcTimeRemaining(past)
+    expect(result.expired).toBe(true)
+    expect(result.urgent).toBe(false)
+    expect(result.years).toBe(0)
+    expect(result.months).toBe(0)
+    expect(result.days).toBe(0)
+    expect(result.hours).toBe(0)
+    expect(result.minutes).toBe(0)
+    expect(result.seconds).toBe(0)
+  })
+
+  it('deadline === now でも expired: true', () => {
+    const now = Date.now()
+    expect(calcTimeRemaining(now).expired).toBe(true)
+  })
+
+  it('24 時間未満は urgent: true', () => {
+    const in23h = Date.now() + 23 * 60 * 60 * 1000
+    const result = calcTimeRemaining(in23h)
+    expect(result.expired).toBe(false)
+    expect(result.urgent).toBe(true)
+  })
+
+  it('24 時間ちょうどは urgent: false (境界)', () => {
+    const in24h = Date.now() + 24 * 60 * 60 * 1000
+    const result = calcTimeRemaining(in24h)
+    expect(result.urgent).toBe(false)
+  })
+
+  it('1 年後の日付を年単位で返す', () => {
+    const oneYearLater = new Date('2027-04-26T00:00:00.000Z').getTime()
+    const result = calcTimeRemaining(oneYearLater)
+    expect(result.years).toBe(1)
+    expect(result.months).toBe(0)
+    expect(result.days).toBe(0)
+  })
+
+  it('秒の繰り下がり計算', () => {
+    vi.setSystemTime(new Date('2026-04-26T12:00:30.000Z'))
+    const target = new Date('2026-04-26T12:01:10.000Z').getTime()
+    const result = calcTimeRemaining(target)
+    expect(result.minutes).toBe(0)
+    expect(result.seconds).toBe(40)
+  })
+
+  it('日の繰り下がり計算 (前月の日数を使用)', () => {
+    vi.setSystemTime(new Date('2026-03-15T00:00:00.000Z'))
+    const target = new Date('2026-04-10T00:00:00.000Z').getTime()
+    const result = calcTimeRemaining(target)
+    expect(result.months).toBe(0)
+    expect(result.days).toBe(26)
+  })
+
+  it('月の繰り下がり計算', () => {
+    vi.setSystemTime(new Date('2026-03-01T00:00:00.000Z'))
+    const target = new Date('2027-02-01T00:00:00.000Z').getTime()
+    const result = calcTimeRemaining(target)
+    expect(result.years).toBe(0)
+    expect(result.months).toBe(11)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.13
         version: 2.4.13
+      happy-dom:
+        specifier: 20.9.0
+        version: 20.9.0
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
       wrangler:
         specifier: ^4.81.1
         version: 4.81.1
@@ -29,7 +35,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.3
-        version: 4.2.0(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.2.0(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
       tailwindcss:
         specifier: ^4.1.3
         version: 4.2.0
@@ -38,10 +44,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.1
-        version: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
       vite-plugin-solid:
         specifier: ^2.11.6
-        version: 2.11.10(solid-js@1.9.11)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 2.11.10(solid-js@1.9.11)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
 
   apps/web:
     dependencies:
@@ -57,7 +63,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.3
-        version: 4.2.0(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.2.0(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
       tailwindcss:
         specifier: ^4.1.3
         version: 4.2.0
@@ -66,10 +72,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.1
-        version: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
       vite-plugin-solid:
         specifier: ^2.11.6
-        version: 2.11.10(solid-js@1.9.11)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 2.11.10(solid-js@1.9.11)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
 
   packages/config: {}
 
@@ -877,6 +883,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.0':
     resolution: {integrity: sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q==}
 
@@ -979,8 +988,56 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   babel-plugin-jsx-dom-expressions@0.40.5:
     resolution: {integrity: sha512-8TFKemVLDYezqqv4mWz+PhRrkryTzivTGu0twyLrOkVZ0P63COx2Y04eVsUjFlwSOXui1z3P3Pn209dokWnirg==}
@@ -1011,6 +1068,10 @@ packages:
 
   caniuse-lite@1.0.30001772:
     resolution: {integrity: sha512-mIwLZICj+ntVTw4BT2zfp+yu/AqV6GMKfJVJMx3MwPxs+uk/uj2GLl2dH8LQbjiLDX66amCga5nKFyDgRR43kg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1046,8 +1107,15 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1062,6 +1130,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1083,6 +1158,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
@@ -1208,6 +1287,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -1256,6 +1338,9 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   solid-js@1.9.11:
     resolution: {integrity: sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==}
 
@@ -1268,6 +1353,12 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -1279,9 +1370,20 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1290,6 +1392,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
@@ -1362,6 +1467,56 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   workerd@1.20260409.1:
     resolution: {integrity: sha512-kuWP20fAaqaLBqLbvUfY9nCF6c3C78L60G9lS6eVwBf+v8trVFIsAdLB/FtrnKm7vgVvpDzvFAfB80VIiVj95w==}
     engines: {node: '>=16'}
@@ -1379,6 +1534,18 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1945,6 +2112,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2006,12 +2175,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.0
 
-  '@tailwindcss/vite@4.2.0(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@tailwindcss/vite@4.2.0(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
       '@tailwindcss/node': 4.2.0
       '@tailwindcss/oxide': 4.2.0
       tailwindcss: 4.2.0
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -2034,7 +2203,67 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
 
   babel-plugin-jsx-dom-expressions@0.40.5(@babel/core@7.29.0):
     dependencies:
@@ -2066,6 +2295,8 @@ snapshots:
 
   caniuse-lite@1.0.30001772: {}
 
+  chai@6.2.2: {}
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
@@ -2087,7 +2318,11 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   error-stack-parser-es@1.0.5: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2149,6 +2384,12 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -2159,6 +2400,18 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   html-entities@2.3.3: {}
 
@@ -2253,6 +2506,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  obug@2.1.1: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -2343,6 +2598,8 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
+  siginfo@2.0.0: {}
+
   solid-js@1.9.11:
     dependencies:
       csstype: 3.2.3
@@ -2360,21 +2617,33 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
   supports-color@10.2.2: {}
 
   tailwindcss@4.2.0: {}
 
   tapable@2.3.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@3.1.0: {}
+
   tslib@2.8.1:
     optional: true
 
   typescript@5.9.3: {}
+
+  undici-types@7.19.2: {}
 
   undici@7.24.4: {}
 
@@ -2388,7 +2657,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1)):
+  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -2396,12 +2665,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.11
       solid-refresh: 0.6.3(solid-js@1.9.11)
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
-      vitefu: 1.1.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1):
+  vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2410,13 +2679,49 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
 
-  vitefu@1.1.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)):
     optionalDependencies:
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
+
+  whatwg-mimetype@3.0.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260409.1:
     optionalDependencies:
@@ -2443,6 +2748,8 @@ snapshots:
       - utf-8-validate
 
   ws@8.18.0: {}
+
+  ws@8.20.0: {}
 
   yallist@3.1.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['{apps,packages}/*/src/**/*.{test,spec}.{ts,tsx}'],
+  },
+})


### PR DESCRIPTION
closes #11

## 概要
Vitest を導入し、コアロジックの純粋関数に対するテストを追加。

## 導入したもの
- `vitest@4.1.5` (固定バージョン)
- `happy-dom@20.9.0` (`localStorage` などブラウザ API 用)
- ルート `vitest.config.ts` を追加 (`environment: 'happy-dom'`)
- `package.json` scripts: `test` / `test:watch`

## テスト内容
| ファイル | 対象 | ケース数 |
|---|---|---|
| `packages/ui/src/countdown.test.ts` | `calcTimeRemaining` / `padNum` / `padYear` | 14 |
| `packages/ui/src/countdown-card/utils.test.ts` | `elapsedDays` / `consumed` / `formatDate` / `formatDateISO` | 14 |
| `apps/web/src/store.test.ts` | `loadCountdowns` / `addCountdown` / `updateCountdown` / `removeCountdown` | 11 |

合計 39 ケース。

## スコープ外 (フォローアップ)
- #19 コンポーネントテスト (`@solidjs/testing-library`)
- #20 バリデーション関数の抽出 + `apps/extension/src/store.ts` のテスト (`chrome.storage` モック必要)

## 動作確認
- [x] `pnpm test` 39 / 39 passed
- [x] `pnpm exec biome check .` クリーン
- [x] `pnpm build` 両アプリ成功