### PR TITLE
deadline 到達前の 100% 表示を修正 (closes #23)

### DIFF
--- a/packages/ui/src/countdown-card/utils.ts
+++ b/packages/ui/src/countdown-card/utils.ts
@@ -9,7 +9,9 @@ export function consumed(startedAt: number, deadline: number): number {
   const total = deadline - startedAt
   if (total <= 0) return 100
   const passed = Date.now() - startedAt
-  return Math.min(100, Math.max(0, Math.round((passed / total) * 100)))
+  if (passed <= 0) return 0
+  if (passed >= total) return 100
+  return Math.min(99, Math.floor((passed / total) * 100))
 }
 
 export function formatDate(ts: number): string {


### PR DESCRIPTION
## 概要

`consumed` 関数で `Math.round` を使っていたため、99.5% 以上で 100% に切り上げられ、deadline 到達前にも関わらず 100% と表示されるバグを修正。

closes #23

## 変更点

- `Math.round` → `Math.floor` に変更
- `passed >= total` のときだけ 100 を返し、それ以外は最大 99 にクランプ
- `passed <= 0` のとき 0 を明示的に返す

## 動作確認

- [ ] deadline 到達前に 100% にならないこと
- [ ] deadline 到達後は 100% になること
- [ ] started 直後は 0% になること